### PR TITLE
Bugfix/font name split

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ session_data = {
 # Load pre-computed font embeddings from CSV
 def load_font_embeddings():
     font_data = []
-    with open('data/embeddings.csv', mode='r') as file:
+    with open('data/embeddings_updated.csv', mode='r') as file:
         reader = csv.DictReader(file)
         for row in reader:
             font_data.append({

--- a/data/format_font_names.py
+++ b/data/format_font_names.py
@@ -1,0 +1,51 @@
+import pandas as pd
+import re
+import requests
+
+# Load the CSV file
+input_path = 'data/embeddings.csv'
+output_path = 'data/embeddings_updated.csv'
+df = pd.read_csv(input_path)
+
+# List to store fonts that couldn't be validated
+unsuccessful_fonts = []
+
+# Common words in font names for better splitting guesses
+common_words = ["bold", "light", "script", "serif", "sans", "display", "mono", "condensed", "fat", "thin", "italic", "hand", "one"]
+
+# Function to split and capitalize font names
+def split_and_capitalize(name):
+    # Split using common words and regex patterns, then capitalize each word
+    for word in common_words:
+        name = re.sub(f'({word})', r' \1', name)
+    return ' '.join(word.capitalize() for word in name.split())
+
+# Function to check if the Google Fonts link works
+def check_google_fonts_link(name):
+    formatted_font = name.replace(" ", "+")
+    url = f"https://fonts.googleapis.com/css?family={formatted_font}&display=swap"
+    response = requests.head(url)
+    return response.status_code == 200
+
+# Apply the split and capitalize function, then check link validity
+def format_and_validate_font_name(name):
+    formatted_name = split_and_capitalize(name)
+    
+    # Check if the link works; if not, log as unsuccessful
+    if check_google_fonts_link(formatted_name):
+        return formatted_name
+    else:
+        unsuccessful_fonts.append(name)
+        return name  # Return original name if the link check fails
+
+# Update the "Name" column with validated font names
+df['Name'] = df['Name'].apply(format_and_validate_font_name)
+
+# Save the updated DataFrame
+df.to_csv(output_path, index=False)
+print(f"Updated CSV saved to {output_path}")
+
+# Output list of unsuccessful fonts for review
+if unsuccessful_fonts:
+    print("The following fonts were unsuccessful and may need manual review:")
+    print(unsuccessful_fonts)

--- a/templates/result.html
+++ b/templates/result.html
@@ -31,9 +31,9 @@
         }
     </style>
 
-    <!-- Load Google Fonts dynamically with proper capitalization -->
+    <!-- Load Google Fonts dynamically -->
     {% for font in api_result %}
-        {% set formatted_font = font[0].capitalize() %}
+        {% set formatted_font = font[0] %}
         <link href="https://fonts.googleapis.com/css?family={{ formatted_font | replace(' ', '+') }}&display=swap" rel="stylesheet">
     {% endfor %}
 </head>
@@ -66,23 +66,25 @@
                     </thead>
                     <tbody>
                         {% for font in api_result %}
-                        <tr class="hover">
-                            <th>{{ loop.index }}</th>
-                            <td class="font-semibold">
-                                <a href="{{ font[3] }}" target="_blank" class="font-link">
-                                    {{ font[0] }}
-                                </a></td>
-                            <td style="font-family: '{{ font[0] }}'; font-size: 1.25rem;" class="preview">
-                                The quick brown fox jumps over the lazy dog.
-                            </td>
-                            <td>{{ "%.2f" | format(font[2] * 100) }}%</td>
-                            <td>
-                                <!-- Remove button to replace the font -->
-                                <form method="POST" action="{{ url_for('remove_font', index=loop.index0) }}">
-                                    <button type="submit" class="btn btn-secondary btn-xs">X</button>
-                                </form>
-                            </td>
-                        </tr>
+                            {% set formatted_font = font[0] %} <!-- Set the formatted font name here -->
+                            <tr class="hover">
+                                <th>{{ loop.index }}</th>
+                                <td class="font-semibold">
+                                    <a href="{{ font[3] }}" target="_blank" class="font-link">
+                                        {{ formatted_font }}
+                                    </a>
+                                </td>
+                                <td style="font-family: '{{ formatted_font }}'; font-size: 1.25rem;" class="preview">
+                                    The quick brown fox jumps over the lazy dog.
+                                </td>
+                                <td>{{ "%.2f" | format(font[2] * 100) }}%</td>
+                                <td>
+                                    <!-- Remove button to replace the font -->
+                                    <form method="POST" action="{{ url_for('remove_font', index=loop.index0) }}">
+                                        <button type="submit" class="btn btn-secondary btn-xs">X</button>
+                                    </form>
+                                </td>
+                            </tr>
                         {% endfor %}
                     </tbody>
                 </table>


### PR DESCRIPTION
This PR addresses an issue with font names in our CSV that were previously concatenated (e.g., `timesnewroman`), causing display issues with Google Fonts. The update splits and capitalizes font names correctly (e.g., `Times New Roman`) for compatibility with Google Fonts API links and font-family settings in the preview.

- Adjusted font names to proper format before applying `<link>` and `font-family` styles.
- Ensured consistent font display across previews.

<img width="1337" alt="Screenshot 2024-11-04 at 5 19 40 pm" src="https://github.com/user-attachments/assets/3bc109cf-2bc1-46ae-9de2-4f736d442279">