### PR TITLE
fix regenerate embeddings, clear cache if regenerating

### DIFF
--- a/app.py
+++ b/app.py
@@ -213,6 +213,12 @@ def result():
         user_data['heading_type'] = request.form.get('heading_type', '')
         user_data['description'] = request.form.get('description', '')
         user_data['mood'] = request.form.get('mood', '')
+        action = request.form.get('action', '')
+
+        # Clear the cached embedding only if the regenerate button was clicked
+        if action == 'regenerate':
+            print("Regenerate action detected. Clearing cached embedding.")
+            user_data["embedding"] = None
 
     user_input = f"{user_data.get('option', '')} {user_data.get('heading_type', '')} {user_data.get('description', '')} {user_data.get('mood', '')}".strip()
 

--- a/templates/result.html
+++ b/templates/result.html
@@ -114,6 +114,7 @@
             
         <!-- User Inputs Form -->
         <form method="POST" action="{{ url_for('result') }}">
+            <input type="hidden" name="action" value="regenerate">
             <div class="space-y-4">
                 <!-- Design Input (Small) -->
                 <label class="block">


### PR DESCRIPTION
This PR resolves the issue where the "Regenerate" button did not trigger new font recommendations due to persistent cached embeddings. Changes include:

- Added logic to check for an `action` parameter in the form submission.
- The cached embedding (`user_data["embedding"]`) is now cleared only if the `action` is identified as "regenerate." This ensures that new user input leads to fresh API calls and updated font recommendations.
- Maintained cache for other cases to improve performance where regeneration is not required.